### PR TITLE
Fix Extra Argument Issues

### DIFF
--- a/src/jobs/ostorlab.yml
+++ b/src/jobs/ostorlab.yml
@@ -25,6 +25,7 @@ parameters:
   extra:
     description: Extra args are to be passed to Ostorlab CLI to create a scan, the common case is setting test credentials or specifying SBOM files for scanning.
     type: string
+    default: ""
 
 docker:
   - image: cimg/python:3.10.0

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-ostorlab --api-key="${OSTORLAB_API_KEY}" ci-scan run --log-flavor=circleci --title="${SCAN_TITLE}" --scan-profile="${SCAN_PROFILE}" --break-on-risk-rating="${BREAK_ON_RISK_RATING}" --max-wait-minutes="${MAX_WAIT_MINUTES}" "${EXTRA}" "${ASSET_TYPE}" "${TARGET}"
+ostorlab --api-key="${OSTORLAB_API_KEY}" ci-scan run --log-flavor=circleci --title="${SCAN_TITLE}" --scan-profile="${SCAN_PROFILE}" --break-on-risk-rating="${BREAK_ON_RISK_RATING}" --max-wait-minutes="${MAX_WAIT_MINUTES}" ${EXTRA:+${EXTRA}} "${ASSET_TYPE}" "${TARGET}"


### PR DESCRIPTION
#### Issue 1: Launch a Scan Without Extra Arguments
When attempting to launch a scan with the following pipeline configuration, the orb complains about an extra argument:

```yaml
version: '2.1'
orbs:
  ostorlab-circleci: ostorlab-circleci/ostorlab@1.0.0
workflows:
  use-my-orb:
    jobs:
      - ostorlab-circleci/ostorlab:
          ostorlab_api_key: test
          asset_type: android-apk
          break_on_risk_rating: HIGH
          max_wait_minutes: 5
          scan_profile: fast_scan
          scan_title: Test_Circle_CI_workflow
          target: oxo_insecure.apk
```

![Issue 1 Image](https://github.com/user-attachments/assets/36791285-907d-4468-b3f1-ca53e1512f12)

**Solution:** Add a default empty string to handle the extra argument issue.

#### Issue 2: Extra Argument Formatting
In the following pipeline configuration, the extra argument causes an issue due to the inclusion of extra double quotes:

```yaml
version: '2.1'
orbs:
  ostorlab-circleci: ostorlab-circleci/ostorlab@1.0.0
workflows:
  use-my-orb:
    jobs:
      - ostorlab-circleci/ostorlab:
          ostorlab_api_key: test
          asset_type: android-apk
          break_on_risk_rating: HIGH
          max_wait_minutes: 5
          scan_profile: fast_scan
          scan_title: Test_Circle_CI_workflow
          target: oxo_insecure.apk
          extra: "--test-credentials-login test --test-credentials-password test_pass"
```

![Issue 2 Image](https://github.com/user-attachments/assets/6a6ad751-3d17-4d8c-b0d6-305ae30d494e)

**Solution:** Remove the extra double quotes to resolve the argument formatting issue.

#### Testing the Solutions Locally

**Before:**
![Before Solution](https://github.com/user-attachments/assets/93458113-7645-426b-9da2-b3e87ffb3450)

**After:**
![After Solution](https://github.com/user-attachments/assets/94254806-2880-4620-adc1-b08be79b24dd)
